### PR TITLE
Error en la definición de la partícula alfa

### DIFF
--- a/notebooks/chernobyl.ipynb
+++ b/notebooks/chernobyl.ipynb
@@ -44,7 +44,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Los isótopos radiactivos son inestables y transmutan a otro elemento (radiactivo o no) emitiendo a su vez radiación de los tipos $\\alpha$ (núcleos de **Helio**, es decir, protón más electrón), $\\beta$ (electrones) o $\\gamma$ (radiación electromagnética); a esta transformación se la conoce como **Decaimiento Radiactivo**.\n",
+    "Los isótopos radiactivos son inestables y transmutan a otro elemento (radiactivo o no) emitiendo a su vez radiación de los tipos $\\alpha$ (núcleos de **Helio-4**, es decir, 2 protones y 2 neutrones), $\\beta$ (electrones) o $\\gamma$ (radiación electromagnética); a esta transformación se la conoce como **Decaimiento Radiactivo**.\n",
     "\n",
     "La velocidad de decaimiento radiactivo obedece a la siguiente ley (donde $\\lambda$ es la **Constante de Decaimiento**):\n",
     "$$ \\displaystyle \\frac{dN(t)}{dt} = - \\lambda N $$\n",


### PR DESCRIPTION
Cambiada la definición de partícula alfa. Las partículas alfa son núcleos de Helio-4, 2 protones y 2 neutrones sin electrones.